### PR TITLE
Revert "Log input to file"

### DIFF
--- a/parser/.gitignore
+++ b/parser/.gitignore
@@ -14,7 +14,6 @@ yarn-error.log
 # Output
 out/*.csv
 out/**/*.json
-out/**/*.log
 out/**/*.png
 
 # Jest

--- a/parser/src/app.ts
+++ b/parser/src/app.ts
@@ -339,15 +339,6 @@ function isBlocked(url: string): boolean {
       await browser.close();
     }
 
-    if (debugMode) {
-      const logFilename = `./out/log/execution-order.log`;
-      fs.appendFile(logFilename, `${fileName}\n`, function(err) {
-        if (err) {
-          return console.error(err);
-        }
-      });
-    }
-
     timeEvent('crawlerCompletedAt');
   }
 }());


### PR DESCRIPTION
The tests are being executed in the order they're defined so there is no
need to log it.

This reverts commit 69d31ee9bd9b090bb622a04698d8284f935040df.