### PR TITLE
Support additional 'without hybrid benefits' instances

### DIFF
--- a/parser/e2e/__snapshots__/cultureCurrencies.test.ts.snap
+++ b/parser/e2e/__snapshots__/cultureCurrencies.test.ts.snap
@@ -1,59 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`End-to-end tests for supported cultures and currencies cs-cz - Čeština EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies cs-cz - Čeština EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies da-dk - Dansk DKK - Danish Krone (kr) 1`] = `"D2 v3,2,8,"1,4107","0,7897","1,1565","0,5355","0,9636","0,3426","0,1842","0,0807","1,305","0,684","1,1608","0,5398""`;
+exports[`End-to-end tests for supported cultures and currencies da-dk - Dansk DKK - Danish Krone (kr) 1`] = `"D2 v3,2,8,"1,4543","0,8141","1,1922","0,5521","0,9934","0,3532","0,1899","0,0832","1,3452","0,7051","1,1966","0,5564""`;
 
-exports[`End-to-end tests for supported cultures and currencies de-de - Deutsch CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1861","0,1042","0,1526","0,0706","0,1271","0,0452","0,0243","0,0106","0,1722","0,0902","0,1531","0,0712""`;
+exports[`End-to-end tests for supported cultures and currencies de-de - Deutsch CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1896","0,1061","0,1554","0,072","0,1295","0,046","0,0248","0,0108","0,1754","0,0919","0,156","0,0725""`;
 
-exports[`End-to-end tests for supported cultures and currencies de-de - Deutsch EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies de-de - Deutsch EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies en-au - English (Australia) AUD - Australian Dollar ($) 1`] = `"D2 v3,2,8,0.3163,0.177,0.2593,0.1201,0.216,0.0768,0.0413,0.0181,0.2925,0.1533,0.2602,0.121"`;
+exports[`End-to-end tests for supported cultures and currencies en-au - English (Australia) AUD - Australian Dollar ($) 1`] = `"D2 v3,2,8,0.3212,0.1798,0.2633,0.1219,0.2194,0.078,0.0419,0.0184,0.2971,0.1557,0.2643,0.1229"`;
 
-exports[`End-to-end tests for supported cultures and currencies en-ca - English (Canada) CAD - Canadian Dollar ($) 1`] = `"D2 v3,2,8,0.2848,0.1594,0.2334,0.1081,0.1945,0.0692,0.0372,0.0163,0.2634,0.1381,0.2343,0.109"`;
+exports[`End-to-end tests for supported cultures and currencies en-ca - English (Canada) CAD - Canadian Dollar ($) 1`] = `"D2 v3,2,8,0.2851,0.1596,0.2338,0.1082,0.1948,0.0693,0.0372,0.0163,0.2638,0.1382,0.2346,0.1091"`;
 
-exports[`End-to-end tests for supported cultures and currencies en-gb - English (UK) GBP - British Pound (£) 1`] = `"D2 v3,2,8,0.1676,0.0938,0.1374,0.0636,0.1145,0.0407,0.0219,0.0096,0.155,0.0813,0.1379,0.0641"`;
+exports[`End-to-end tests for supported cultures and currencies en-gb - English (UK) GBP - British Pound (£) 1`] = `"D2 v3,2,8,0.1695,0.0949,0.1389,0.0643,0.1158,0.0412,0.0221,0.0097,0.1568,0.0822,0.1394,0.0648"`;
 
-exports[`End-to-end tests for supported cultures and currencies en-gb - English (UK) NZD - New Zealand Dollar ($) 1`] = `"D2 v3,2,8,0.3411,0.1909,0.2796,0.1295,0.233,0.0828,0.0445,0.0195,0.3155,0.1654,0.2807,0.1305"`;
+exports[`End-to-end tests for supported cultures and currencies en-gb - English (UK) NZD - New Zealand Dollar ($) 1`] = `"D2 v3,2,8,0.3459,0.1937,0.2836,0.1313,0.2363,0.084,0.0452,0.0198,0.32,0.1677,0.2846,0.1324"`;
 
-exports[`End-to-end tests for supported cultures and currencies en-in - English (India) INR - Indian Rupee (₹) 1`] = `"D2 v3,2,8,17.0902,9.5672,14.0107,6.4877,11.6737,4.1507,2.2315,0.9777,15.8088,8.2859,14.0622,6.5392"`;
+exports[`End-to-end tests for supported cultures and currencies en-in - English (India) INR - Indian Rupee (₹) 1`] = `"D2 v3,2,8,17.2574,9.6608,14.1478,6.5512,11.7879,4.1913,2.2533,0.9873,15.9635,8.3669,14.1998,6.6032"`;
 
 exports[`End-to-end tests for supported cultures and currencies en-us - English (US) USD - US Dollar ($) 1`] = `"D2 v3,2,8,0.209,0.117,0.1713,0.0793,0.1428,0.0508,0.0273,0.012,0.1933,0.1013,0.172,0.08"`;
 
-exports[`End-to-end tests for supported cultures and currencies es-es - Español EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies es-es - Español EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
 exports[`End-to-end tests for supported cultures and currencies es-mx - Español (MX) USD - US Dollar ($) 1`] = `"D2 v3,2,8,0.209,0.117,0.1713,0.0793,0.1428,0.0508,0.0273,0.012,0.1933,0.1013,0.172,0.08"`;
 
-exports[`End-to-end tests for supported cultures and currencies fr-ca - Français (Canada) CAD - Canadian Dollar ($) 1`] = `"D2 v3,2,8,"0,2848","0,1594","0,2334","0,1081","0,1945","0,0692","0,0372","0,0163","0,2634","0,1381","0,2343","0,109""`;
+exports[`End-to-end tests for supported cultures and currencies fr-ca - Français (Canada) CAD - Canadian Dollar ($) 1`] = `"D2 v3,2,8,"0,2851","0,1596","0,2338","0,1082","0,1948","0,0693","0,0372","0,0163","0,2638","0,1382","0,2346","0,1091""`;
 
-exports[`End-to-end tests for supported cultures and currencies fr-fr - Français CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1861","0,1042","0,1526","0,0706","0,1271","0,0452","0,0243","0,0106","0,1722","0,0902","0,1531","0,0712""`;
+exports[`End-to-end tests for supported cultures and currencies fr-fr - Français CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1896","0,1061","0,1554","0,072","0,1295","0,046","0,0248","0,0108","0,1754","0,0919","0,156","0,0725""`;
 
-exports[`End-to-end tests for supported cultures and currencies fr-fr - Français EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies fr-fr - Français EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies hu-hu - Magyar EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies hu-hu - Magyar EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies it-it - Italiano CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1861","0,1042","0,1526","0,0706","0,1271","0,0452","0,0243","0,0106","0,1722","0,0902","0,1531","0,0712""`;
+exports[`End-to-end tests for supported cultures and currencies it-it - Italiano CHF - Swiss Franc. (chf) 1`] = `"D2 v3,2,8,"0,1896","0,1061","0,1554","0,072","0,1295","0,046","0,0248","0,0108","0,1754","0,0919","0,156","0,0725""`;
 
-exports[`End-to-end tests for supported cultures and currencies it-it - Italiano EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies it-it - Italiano EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies ja-jp - 日本語 JPY - Japanese Yen (¥) 1`] = `"D2 v3,2,8,27.8691,15.6014,22.8473,10.5796,19.0363,6.7686,3.6389,1.5944,25.7796,13.5118,22.9313,10.6636"`;
+exports[`End-to-end tests for supported cultures and currencies ja-jp - 日本語 JPY - Japanese Yen (¥) 1`] = `"D2 v3,2,8,29.3635,16.4379,24.0724,11.1469,20.0571,7.1315,3.834,1.6799,27.1619,14.2364,24.1609,11.2354"`;
 
-exports[`End-to-end tests for supported cultures and currencies ko-kr - 한국어 KRW - Korean Won (₩) 1`] = `"D2 v3,2,8,279.2971,156.3529,228.9702,106.026,190.7773,67.8331,36.4677,15.9787,258.3565,135.4123,229.8121,106.8679"`;
+exports[`End-to-end tests for supported cultures and currencies ko-kr - 한국어 KRW - Korean Won (₩) 1`] = `"D2 v3,2,8,276.81,154.9606,226.9313,105.0819,189.0785,67.2291,36.1429,15.8364,256.0559,134.2065,227.7657,105.9163"`;
 
-exports[`End-to-end tests for supported cultures and currencies nb-no - Norsk NOK - Norwegian Krone (kr) 1`] = `"D2 v3,2,8,"2,22","1,2428","1,82","0,8428","1,5164","0,5392","0,2899","0,127","2,0536","1,0763","1,8267","0,8494""`;
+exports[`End-to-end tests for supported cultures and currencies nb-no - Norsk NOK - Norwegian Krone (kr) 1`] = `"D2 v3,2,8,"2,3155","1,2962","1,8983","0,879","1,5816","0,5624","0,3023","0,1325","2,1419","1,1226","1,9052","0,886""`;
 
-exports[`End-to-end tests for supported cultures and currencies nl-nl - Nederlands EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies nl-nl - Nederlands EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies pl-pl - Polski EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies pl-pl - Polski EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies pt-br - Português (Brasil) BRL - Brazilian Real (R$) 1`] = `"D2 v3,2,8,"1,0556","0,591","0,8654","0,4007","0,7211","0,2564","0,1378","0,0604","0,9765","0,5118","0,8686","0,4039""`;
+exports[`End-to-end tests for supported cultures and currencies pt-br - Português (Brasil) BRL - Brazilian Real (R$) 1`] = `"D2 v3,2,8,"1,0469","0,5861","0,8583","0,3974","0,7151","0,2543","0,1367","0,0599","0,9684","0,5076","0,8614","0,4006""`;
 
-exports[`End-to-end tests for supported cultures and currencies pt-pt - Português EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1893","0,1059","0,1552","0,0718","0,1293","0,046","0,0247","0,0108","0,1751","0,0918","0,1557","0,0724""`;
+exports[`End-to-end tests for supported cultures and currencies pt-pt - Português EUR - Euro (€) 1`] = `"D2 v3,2,8,"0,1952","0,1093","0,16","0,0741","0,1334","0,0474","0,0255","0,0112","0,1806","0,0947","0,1606","0,0747""`;
 
-exports[`End-to-end tests for supported cultures and currencies ru-ru - Pусский RUB - Russian Ruble (руб) 1`] = `"D2 v3,2,8,"17,2948","9,6818","14,1784","6,5654","11,8134","4,2004","2,2582","0,9894","15,9981","8,3851","14,2305","6,6175""`;
+exports[`End-to-end tests for supported cultures and currencies ru-ru - Pусский RUB - Russian Ruble (руб) 1`] = `"D2 v3,2,8,"16,6991","9,3483","13,6901","6,3393","11,4065","4,0557","2,1804","0,9554","15,4471","8,0963","13,7404","6,3896""`;
 
-exports[`End-to-end tests for supported cultures and currencies sv-se - Svenska SEK - Swedish Krona (kr) 1`] = `"D2 v3,2,8,"2,159","1,2086","1,77","0,8196","1,4747","0,5244","0,2819","0,1235","1,9971","1,0467","1,7765","0,8261""`;
+exports[`End-to-end tests for supported cultures and currencies sv-se - Svenska SEK - Swedish Krona (kr) 1`] = `"D2 v3,2,8,"2,2576","1,2638","1,8508","0,857","1,5421","0,5483","0,2948","0,1292","2,0883","1,0946","1,8576","0,8638""`;
 
 exports[`End-to-end tests for supported cultures and currencies tr-tr - Türkçe USD - US Dollar ($) 1`] = `"D2 v3,2,8,"0,209","0,117","0,1713","0,0793","0,1428","0,0508","0,0273","0,012","0,1933","0,1013","0,172","0,08""`;
 
-exports[`End-to-end tests for supported cultures and currencies zh-tw - 中文(繁體) TWD - Taiwanese Dollar (NT$) 1`] = `"D2 v3,2,8,6.4217,3.5949,5.2646,2.4378,4.3864,1.5597,0.8385,0.3674,5.9403,3.1135,5.284,2.4572"`;
+exports[`End-to-end tests for supported cultures and currencies zh-tw - 中文(繁體) TWD - Taiwanese Dollar (NT$) 1`] = `"D2 v3,2,8,6.425,3.5968,5.2672,2.439,4.3887,1.5604,0.8389,0.3676,5.9433,3.115,5.2866,2.4584"`;

--- a/parser/e2e/__snapshots__/gpu.test.ts.snap
+++ b/parser/e2e/__snapshots__/gpu.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`End-to-end tests for instances with GPUs No reserved instances 1`] = `"H16mr,16,224,4.742,2.861,N/A,N/A,N/A,N/A,0.6658,0.2861,3.1175,2.3815,2.501,1.765"`;
+
+exports[`End-to-end tests for instances with GPUs No savings plan 1`] = `"NV18ads A10 v5,18,220,2.908,2.08,2.1592,1.3312,1.7432,0.9152,1.1632,0.832,N/A,N/A,N/A,N/A"`;

--- a/parser/e2e/gpu.test.ts
+++ b/parser/e2e/gpu.test.ts
@@ -1,0 +1,15 @@
+import assert from "./assertExtensions";
+
+describe('End-to-end tests for instances with GPUs', () => {
+  const culture = 'en-us';
+  const currency = 'usd';
+  const operatingSystem = 'windows';
+
+  test('No reserved instances', (done) => {
+    assert(done, culture, currency, operatingSystem, 'H16mr');
+  });
+
+  test('No savings plan', (done) => {
+    assert(done, culture, currency, operatingSystem, 'NV18ads A10 v5');
+  });
+});

--- a/parser/src/azurePortalExtensions.ts
+++ b/parser/src/azurePortalExtensions.ts
@@ -345,10 +345,17 @@ export function getPricing(): PartialVmPricing[] {
 
     const ram = getRam(tr);
 
-    const payAsYouGo = getPrice(tr, 'td:nth-child(5)');
-    const oneYear = getPrice(tr, 'td:nth-child(6)');
-    const threeYear = getPrice(tr, 'td:nth-child(7)');
-    const spot = getPrice(tr, 'td:nth-child(8)');
+    const cellCount = tr.querySelectorAll('td').length;
+    const hasGpu = cellCount === 10;
+    const payAsYouGoOffset = 5 + (hasGpu ? 1 : 0);
+    const oneYearOffset = payAsYouGoOffset + 1;
+    const threeYearOffset = oneYearOffset + 1;
+    const spotOffset = threeYearOffset + 1;
+
+    const payAsYouGo = getPrice(tr, `td:nth-child(${payAsYouGoOffset})`);
+    const oneYear = getPrice(tr, `td:nth-child(${oneYearOffset})`);
+    const threeYear = getPrice(tr, `td:nth-child(${threeYearOffset})`);
+    const spot = getPrice(tr, `td:nth-child(${spotOffset})`);
 
     if (payAsYouGo === undefined &&
         oneYear === undefined &&

--- a/parser/src/azurePortalExtensions.ts
+++ b/parser/src/azurePortalExtensions.ts
@@ -70,7 +70,25 @@ export class AzurePortal {
       savingsPlansWithoutHybridBenefits = await this.p.evaluate(() => getPricing());
 
       if (savingsPlanWithHybridBenefits.length !== savingsPlansWithoutHybridBenefits.length) {
-        throw `Expected same count of savings plan instances with hybrid benefits (${savingsPlanWithHybridBenefits.length}) and without (${savingsPlansWithoutHybridBenefits.length}), good luck!`;
+        const instancesWithHybridBenefits = savingsPlanWithHybridBenefits.map(v => v.instance);
+        const instancesWithoutHybridBenefits = savingsPlansWithoutHybridBenefits.map(v => v.instance);
+        const additionalWith = instancesWithHybridBenefits.filter(v => !instancesWithoutHybridBenefits.includes(v));
+        const additionalWithout = instancesWithoutHybridBenefits.filter(v => !instancesWithHybridBenefits.includes(v));
+
+        if (additionalWith.length > 0)
+        {
+          throw `Unexpected additional savings plan instance(s) with hybrid benefits: ${JSON.stringify(additionalWith)}. We only support additional without hybrid benefits instances.`;
+        }
+
+        additionalWithout.forEach(without => {
+          var offset = savingsPlansWithoutHybridBenefits.findIndex(v => v.instance == without);
+          var unavailableVm = <PartialVmPricing> {
+            instance: without,
+            vCpu: savingsPlansWithoutHybridBenefits[offset].vCpu,
+            ram: savingsPlansWithoutHybridBenefits[offset].ram
+          };
+          savingsPlanWithHybridBenefits.splice(offset, 0, unavailableVm);
+        });
       }
     } else {
       savingsPlansWithoutHybridBenefits = savingsPlanPricing;
@@ -89,7 +107,25 @@ export class AzurePortal {
       reservedWithHybridBenefits = await this.p.evaluate(() => getPricing());
 
       if (reservedWithoutHybridBenefits.length !== reservedWithHybridBenefits.length) {
-        throw `Expected same count of reserved instances with hybrid benefits (${reservedWithHybridBenefits.length}) and without (${reservedWithoutHybridBenefits.length}), good luck!`;
+        const instancesWithHybridBenefits = reservedWithHybridBenefits.map(v => v.instance);
+        const instancesWithoutHybridBenefits = reservedWithoutHybridBenefits.map(v => v.instance);
+        const additionalWith = instancesWithHybridBenefits.filter(v => !instancesWithoutHybridBenefits.includes(v));
+        const additionalWithout = instancesWithoutHybridBenefits.filter(v => !instancesWithHybridBenefits.includes(v));
+
+        if (additionalWith.length > 0)
+        {
+          throw `Unexpected additional reserved instance(s) with hybrid benefits: ${JSON.stringify(additionalWith)}. We only support additional without hybrid benefits instances.`;
+        }
+
+        additionalWithout.forEach(without => {
+          var offset = reservedWithoutHybridBenefits.findIndex(v => v.instance == without);
+          var unavailableVm = <PartialVmPricing> {
+            instance: without,
+            vCpu: reservedWithoutHybridBenefits[offset].vCpu,
+            ram: reservedWithoutHybridBenefits[offset].ram
+          };
+          reservedWithHybridBenefits.splice(offset, 0, unavailableVm);
+        });
       }
     } else {
       reservedWithoutHybridBenefits = reservedPricing;


### PR DESCRIPTION
- Support additional 'without hybrid benefits' instances. Some Windows instances don't have hybrid benefits
- Support `GPU` instances. They have an additional column so the prices were wrong
- Reflect price changes