### PR TITLE
Support different with and without hybrid benefits

### DIFF
--- a/parser/src/vmPricing.test.ts
+++ b/parser/src/vmPricing.test.ts
@@ -1,4 +1,4 @@
-import { addUnavailableVms, PartialVmPricing } from "./vmPricing";
+import { addUnavailableVms, discardDuplicateVms, PartialVmPricing } from "./vmPricing";
 
 function getVm(name: string, vCpu: number, ram: number): PartialVmPricing {
   return <PartialVmPricing>{
@@ -86,6 +86,30 @@ describe('Add unavailable VMs', () => {
       let withoutHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('A', 1, 1)];
 
       expect(() => addUnavailableVms(withHybridBenefits, withoutHybridBenefits)).toThrow();
+    });
+  });
+});
+
+describe('Discard duplicate VMs', () => {
+  describe('Given no duplicate', () => {
+    test('Then unmodified list', () => {
+      let vms = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+
+      discardDuplicateVms(vms);
+
+      const expected = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+      expect(vms).toEqual(expected);
+    });
+  });
+
+  describe('Given duplicates', () => {
+    test('Then duplicate instances are removed', () => {
+      let vms = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3), getVm('D', 4, 4), getVm('D', 5, 5), getVm('B', 6, 6), getVm('E', 7, 7), getVm('B', 8, 8)];
+
+      discardDuplicateVms(vms);
+
+      const expected = [getVm('A', 1, 1), getVm('C', 3, 3), getVm('E', 7, 7)];
+      expect(vms).toEqual(expected);
     });
   });
 });

--- a/parser/src/vmPricing.test.ts
+++ b/parser/src/vmPricing.test.ts
@@ -70,4 +70,22 @@ describe('Add unavailable VMs', () => {
       expect(withoutHybridBenefits).toEqual(expected);
     });
   });
+
+  describe('Given duplicate with hybrid benefits', () => {
+    test('Then throw', () => {
+      let withHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('A', 1, 1)];
+      let withoutHybridBenefits = [getVm('A', 1, 1)];
+
+      expect(() => addUnavailableVms(withHybridBenefits, withoutHybridBenefits)).toThrow();
+    });
+  });
+
+  describe('Given duplicate without hybrid benefits', () => {
+    test('Then throw', () => {
+      let withHybridBenefits = [getVm('A', 1, 1)];
+      let withoutHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('A', 1, 1)];
+
+      expect(() => addUnavailableVms(withHybridBenefits, withoutHybridBenefits)).toThrow();
+    });
+  });
 });

--- a/parser/src/vmPricing.test.ts
+++ b/parser/src/vmPricing.test.ts
@@ -1,0 +1,73 @@
+import { addUnavailableVms, PartialVmPricing } from "./vmPricing";
+
+function getVm(name: string, vCpu: number, ram: number): PartialVmPricing {
+  return <PartialVmPricing>{
+    instance: name,
+    vCpu: vCpu,
+    ram: ram
+  };
+}
+
+describe('Add unavailable VMs', () => {
+  describe('Given same VMs with and without hybrid benefits', () => {
+    test('Then VMs are unchanged', () => {
+      let withHybridBenefits = [getVm('A', 1, 1)];
+      let withoutHybridBenefits = [getVm('A', 1, 1)];
+
+      addUnavailableVms(withHybridBenefits, withoutHybridBenefits);
+
+      const expected = [getVm('A', 1, 1)];
+      expect(withHybridBenefits).toEqual(expected);
+      expect(withoutHybridBenefits).toEqual(expected);
+    });
+  });
+
+  describe('Given VM not present in without hybrid benefits list', () => {
+    test('Then VM added as unavailable to instances without hybrid benefits', () => {
+      let withHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+      let withoutHybridBenefits = [getVm('A', 1, 1), getVm('C', 3, 3)];
+
+      addUnavailableVms(withHybridBenefits, withoutHybridBenefits);
+
+      const expectedWithoutHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+      expect(withoutHybridBenefits).toEqual(expectedWithoutHybridBenefits);
+    });
+  });
+
+  describe('Given VM not present in with hybrid benefits list', () => {
+    test('Then VM added as unavailable to instances with hybrid benefits', () => {
+      let withHybridBenefits = [getVm('A', 1, 1), getVm('C', 3, 3)];
+      let withoutHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+
+      addUnavailableVms(withHybridBenefits, withoutHybridBenefits);
+
+      const expectedWithHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3)];
+      expect(withHybridBenefits).toEqual(expectedWithHybridBenefits);
+    });
+  });
+
+  describe('Given different VMs present in with and without hybrid benefits lists', () => {
+    test('Then VMs added as unavailable to both with and without hybrid benefits lists', () => {
+      let withHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('D', 4, 4)];
+      let withoutHybridBenefits = [getVm('A', 1, 1), getVm('C', 3, 3), getVm('D', 4, 4)];
+
+      addUnavailableVms(withHybridBenefits, withoutHybridBenefits);
+
+      const expected = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3), getVm('D', 4, 4)];
+      expect(withHybridBenefits).toEqual(expected);
+      expect(withoutHybridBenefits).toEqual(expected);
+    });
+  });
+
+  describe('Given multiple VMs in a row not present in without hybrid benefits list', () => {
+    test('Then VMs added as unavailable to without hybrid benefits list', () => {
+      let withHybridBenefits = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3), getVm('D', 4, 4), getVm('E', 5, 5), getVm('F', 6, 6), getVm('G', 7, 7)];
+      let withoutHybridBenefits = [getVm('A', 1, 1), getVm('D', 4, 4), getVm('G', 7, 7)];
+
+      addUnavailableVms(withHybridBenefits, withoutHybridBenefits);
+
+      const expected = [getVm('A', 1, 1), getVm('B', 2, 2), getVm('C', 3, 3), getVm('D', 4, 4), getVm('E', 5, 5), getVm('F', 6, 6), getVm('G', 7, 7)];
+      expect(withoutHybridBenefits).toEqual(expected);
+    });
+  });
+});

--- a/parser/src/vmPricing.ts
+++ b/parser/src/vmPricing.ts
@@ -25,3 +25,32 @@ export interface PartialVmPricing {
   threeYear: number;
   spot: number;
 }
+
+function addUnavailable(additionalInstances: string[], additional: PartialVmPricing[], toFill: PartialVmPricing[]): void {
+  additionalInstances.forEach(additionalInstance => {
+    var offset = additional.findIndex(v => v.instance == additionalInstance);
+    var unavailableVm = <PartialVmPricing> {
+      instance: additionalInstance,
+      vCpu: additional[offset].vCpu,
+      ram: additional[offset].ram
+    };
+    toFill.splice(offset, 0, unavailableVm);
+  });
+}
+
+/**
+ * Ensure that if a VM is present in one of the arrays and not the other it will be added so that both arrays
+ * have the same VMs in the same order.
+ * @param withHybridBenefits the instances available with hybrid benefits. The array will be modified if the
+ * other one has additional instances.
+ * @param withoutHybridBenefits the instances available without hybrid benefits. The array will be modified
+ * if the other one has additional instances.
+ */
+export function addUnavailableVms(withHybridBenefits: PartialVmPricing[], withoutHybridBenefits: PartialVmPricing[]): void {
+  const instancesWithHybridBenefits = withHybridBenefits.map(v => v.instance);
+  const instancesWithoutHybridBenefits = withoutHybridBenefits.map(v => v.instance);
+  const additionalWith = instancesWithHybridBenefits.filter(v => !instancesWithoutHybridBenefits.includes(v));
+  const additionalWithout = instancesWithoutHybridBenefits.filter(v => !instancesWithHybridBenefits.includes(v));
+  addUnavailable(additionalWith, withHybridBenefits, withoutHybridBenefits);
+  addUnavailable(additionalWithout, withoutHybridBenefits, withHybridBenefits);
+}

--- a/parser/src/vmPricing.ts
+++ b/parser/src/vmPricing.ts
@@ -38,6 +38,16 @@ function addUnavailable(additionalInstances: string[], additional: PartialVmPric
   });
 }
 
+function validateUnique(instances: string[]): void {
+  const uniqueWith = [...new Set(instances)];
+
+  if (instances.length !== uniqueWith.length) {
+    let duplicates: string[] = [];
+    instances.forEach((i, o) => {if (instances.indexOf(i) !== o) { duplicates.push(i); }});
+    throw `Instances contain duplicates ${duplicates}.`;
+  }
+}
+
 /**
  * Ensure that if a VM is present in one of the arrays and not the other it will be added so that both arrays
  * have the same VMs in the same order.
@@ -48,7 +58,9 @@ function addUnavailable(additionalInstances: string[], additional: PartialVmPric
  */
 export function addUnavailableVms(withHybridBenefits: PartialVmPricing[], withoutHybridBenefits: PartialVmPricing[]): void {
   const instancesWithHybridBenefits = withHybridBenefits.map(v => v.instance);
+  validateUnique(instancesWithHybridBenefits);
   const instancesWithoutHybridBenefits = withoutHybridBenefits.map(v => v.instance);
+  validateUnique(instancesWithoutHybridBenefits);
   const additionalWith = instancesWithHybridBenefits.filter(v => !instancesWithoutHybridBenefits.includes(v));
   const additionalWithout = instancesWithoutHybridBenefits.filter(v => !instancesWithHybridBenefits.includes(v));
   addUnavailable(additionalWith, withHybridBenefits, withoutHybridBenefits);


### PR DESCRIPTION
- Support different _with_ and _without hybrid benefits_ instances: some instances are only available with or without hybrid benefits. I initially made the assumption that instances without hybrid benefits were a superset of instances with hybrid benefits. It turned out to be wrong.
- Discard duplicate VMs: due to what seems to be an operator error, some instance names are duplicated. As I use instance names to identify VMs and match instances, this sort of broke everything. The easiest solution is to discard duplicate instances (later on I might try to discard only the incorrect one(s)). Unfortunately it means that the duplicate instances will be missing (better not to provide any price than an incorrect price).

Example with the `F16s v2` instance for the `zh-tw` culture without hybrid benefits:

![image](https://github.com/user-attachments/assets/52b15420-9542-4deb-a439-32d05bcc7090)

![image](https://github.com/user-attachments/assets/87f3de19-2520-4e69-b67e-de60919b7531)

In this example, it's obvious that the second `F16s v2` can safely be renamed to `L16s v2` but I need to do more analysis to determine if it's always the case.