### PR TITLE
Lower case Operating System and region when parsing VMs

### DIFF
--- a/coster/.editorconfig
+++ b/coster/.editorconfig
@@ -188,6 +188,10 @@ dotnet_diagnostic.IDE2003.severity = warning
 # csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental
 dotnet_diagnostic.IDE2004.severity = warning
 
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1308
+# The data I'm matching to is in lower case
+dotnet_diagnostic.CA1308.severity = none
+
 # CSharp code style settings:
 [*.cs]
 # Newline settings

--- a/coster/src/AzureVmCoster/Models/Csv/InputVmMap.cs
+++ b/coster/src/AzureVmCoster/Models/Csv/InputVmMap.cs
@@ -1,3 +1,6 @@
+using CsvHelper;
+using CsvHelper.TypeConversion;
+
 namespace AzureVmCoster.Models.Csv;
 
 public sealed class InputVmMap : ClassMap<InputVm>
@@ -6,8 +9,16 @@ public sealed class InputVmMap : ClassMap<InputVm>
     {
         Map(v => v.Cpu).Name("CPU");
         Map(v => v.Ram).Name("RAM").TypeConverterOption.NumberStyles(NumberStyles.Currency);
-        Map(v => v.OperatingSystem).Name("Operating System");
+        Map(v => v.OperatingSystem).Name("Operating System").TypeConverter<LowercaseConverter>();
         Map(v => v.Name);
-        Map(v => v.Region);
+        Map(v => v.Region).TypeConverter<LowercaseConverter>();
+    }
+
+    private sealed class LowercaseConverter : DefaultTypeConverter
+    {
+        public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+        {
+            return text?.ToLowerInvariant();
+        }
     }
 }

--- a/coster/tests/AzureVmCosterTests/SampleInputs/input-en-au-wrong-case.csv
+++ b/coster/tests/AzureVmCosterTests/SampleInputs/input-en-au-wrong-case.csv
@@ -1,0 +1,2 @@
+RAM,Region,CPU,Name,Operating System
+8,Us-West,4,name-1,Windows

--- a/coster/tests/AzureVmCosterTests/Services/InputVmParserTests.cs
+++ b/coster/tests/AzureVmCosterTests/Services/InputVmParserTests.cs
@@ -71,4 +71,23 @@ public class InputVmParserTests
         Assert.NotNull(actualVms);
         actualVms.Should().BeEquivalentTo(_expected);
     }
+
+    [Fact]
+    public void GivenRegionAndOperatingSystemWithUnexpectedCase_WhenParse_ThenLowerCase()
+    {
+        // Arrange
+        var file = new FileInfo("SampleInputs/input-en-au-wrong-case.csv");
+        var culture = new CultureInfo("en-au");
+
+        // Act
+        var actualVms = InputVmParser.Parse(file, culture);
+
+        // Assert
+        var expected = new List<InputVm>
+        {
+            new() {Name = "name-1", Region = "us-west", Cpu = 4, Ram = 8, OperatingSystem = "windows"}
+        };
+        Assert.NotNull(actualVms);
+        actualVms.Should().BeEquivalentTo(expected);
+    }
 }


### PR DESCRIPTION
Better to be lenient on user input, e.g. 'Windows' should match 'windows'.